### PR TITLE
Travis: Fix failures due to chrome-chromedriver incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 group: edge
 os:
     - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
     - jupyter kernelspec list
 
     # selenium
-    - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
+    - wget https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip
     - unzip chromedriver_linux64.zip -d $HOME/miniconda/bin
 
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,4 @@ notifications:
             - ben.bob@gmail.com
         on_success: never
         on_failure: always
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - conda install -c conda-forge feather-format=0.3.1
 
     # SoS Notebook
-    - sudo apt-get install libmagickwand-dev libmagickcore5-extra graphviz
+    - sudo apt-get install libmagickwand-dev graphviz
     - pip install jedi notebook nbconvert nbformat pyyaml psutil tqdm scipy
     - pip install pygments ipython wand graphviz sos sos-notebook selenium
     - python -m sos_notebook.install


### PR DESCRIPTION
Not sure if you were aware, but your CI tests on Travis were failing due to an incompatibility between the Chrome version and the chromedriver version.

I dug in a bit, and found that the Travis Chrome addon wasn't installing the latest Chrome version with your settings, and the actual version in your tests dated back from 2017 (Version 63 I think).

<img width="1039" alt="Capture d’écran 2020-05-19 à 23 26 06" src="https://user-images.githubusercontent.com/1421029/82396296-22b6dc00-9a28-11ea-9c88-5f37556c05f0.png">

The reason for this is because the `trusty` distribution doesn't have the updated dpkg tool I think, if I recall from my web search. I couldn't find a way to update that before Travis installs Chrome, but simply removing that dist resolved the issue* (* except that now in the latest dist, libmagickcore5-extra isn't available, but it didn't appear to be necessary here so I removed it).

I also updated the chromedriver for the latest version. If this solution isn't good enough for you and you'd prefer to keep the `trusty` dist, then you would need to remove the Travis call to install Chrome and downgrade the chromdriver to version 2.34 I think.

Here's the Travis log showing that my fork now passes further than your Travis log: https://travis-ci.org/github/mathieuboudreau/sos-julia/builds/689072456

This also brings to light that not all of your unit tests are passing - at least one fails (and I suspect more than one will, with a quick check I made).

Hope this helps!